### PR TITLE
Consider variant alleles instead of genotype alleles when creating the region files

### DIFF
--- a/bam_readcount_helper.py
+++ b/bam_readcount_helper.py
@@ -54,50 +54,42 @@ sample_index = vcf_file.samples.index(sample)
 rc_for_indel = {}
 rc_for_snp   = {}
 for variant in vcf_file:
-    alleles = [variant.REF] + variant.ALT
-    genotype = variant.genotypes[sample_index]
-    gt_alt_alleles = [allele for allele in genotype if allele > 0]
-    used_gt_alt_alleles = [alleles[index] for index in gt_alt_alleles]
-    if len(used_gt_alt_alleles) > 0:
-        var = sorted(used_gt_alt_alleles)[0]
-    else:
-        var = ""
     ref = variant.REF
     chr = variant.CHROM
     start = variant.start
     end = variant.end
     pos = variant.POS
-
-    if len(ref) > 1 or len(var) > 1:
-        #it's an indel or mnp
-        if len(ref) == len(var) or (len(ref) > 1 and len(var) > 1):
-            sys.stderr.write("Complex variant or MNP will be skipped: %s\t%s\t%s\t%s\n" % (chr, pos, ref , var))
-            continue
-        elif len(ref) > len(var):
-            #it's a deletion
-            pos += 1
-            unmodified_ref = ref
-            ref = unmodified_ref[1]
-            var = "-%s" % unmodified_ref[1:]
+    for var in  variant.ALT:
+        if len(ref) > 1 or len(var) > 1:
+            #it's an indel or mnp
+            if len(ref) == len(var) or (len(ref) > 1 and len(var) > 1):
+                sys.stderr.write("Complex variant or MNP will be skipped: %s\t%s\t%s\t%s\n" % (chr, pos, ref , var))
+                continue
+            elif len(ref) > len(var):
+                #it's a deletion
+                pos += 1
+                unmodified_ref = ref
+                ref = unmodified_ref[1]
+                var = "-%s" % unmodified_ref[1:]
+            else:
+                #it's an insertion
+                var = "+%s" % var[1:]
+            if chr not in rc_for_indel:
+                rc_for_indel[chr] = {}
+            if pos not in rc_for_indel[chr]:
+                rc_for_indel[chr][pos] = {}
+            if ref not in rc_for_indel[chr][pos]:
+                rc_for_indel[chr][pos][ref] = {}
+            rc_for_indel[chr][pos][ref] = variant
         else:
-            #it's an insertion
-            var = "+%s" % var[1:]
-        if chr not in rc_for_indel:
-            rc_for_indel[chr] = {}
-        if pos not in rc_for_indel[chr]:
-            rc_for_indel[chr][pos] = {}
-        if ref not in rc_for_indel[chr][pos]:
-            rc_for_indel[chr][pos][ref] = {}
-        rc_for_indel[chr][pos][ref] = variant
-    else:
-        #it's a SNP
-        if chr not in rc_for_snp:
-            rc_for_snp[chr] = {}
-        if pos not in rc_for_snp[chr]:
-            rc_for_snp[chr][pos] = {}
-        if ref not in rc_for_snp[chr][pos]:
-            rc_for_snp[chr][pos][ref] = {}
-        rc_for_snp[chr][pos][ref] = variant
+            #it's a SNP
+            if chr not in rc_for_snp:
+                rc_for_snp[chr] = {}
+            if pos not in rc_for_snp[chr]:
+                rc_for_snp[chr][pos] = {}
+            if ref not in rc_for_snp[chr][pos]:
+                rc_for_snp[chr][pos][ref] = {}
+            rc_for_snp[chr][pos][ref] = variant
 
 if len(rc_for_snp.keys()) > 0:
     region_file = generate_region_list(rc_for_snp)


### PR DESCRIPTION
I've tested this on an example variant and with this change hom-ref (0/0) genotypes at an insertion position are now correctly categorized as indels instead of snvs.